### PR TITLE
ci: modernize release workflow runtime

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,8 +9,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-major-version.yml@v1.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
-
-      

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-minor-version.yml@v1.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -7,9 +7,19 @@ on:
       - alpha/v*/v*
       - release/v*/v*
 
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
-    uses: kungfu-trader/workflows/.github/workflows/.release-new-version.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v2/v2.0
+    with:
+      publish-aws-ci: false
+      publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
     secrets:
       AWS_CI_ACCESS_KEY_ID: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
       AWS_CI_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -7,13 +7,23 @@ on:
       - release/*/*
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   try:
-    uses: kungfu-trader/workflows/.github/workflows/.release-verify.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v2/v2.0
     with:
       enable-linux: true
       enable-macos: false
       enable-windows: false
+      build-container-enabled: false
+      setup-python-enabled: false
+      publish-versioning: false
+      publish-aws-ci: false
+      publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
     secrets:
       AWS_CI_ACCESS_KEY_ID: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
       AWS_CI_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}
@@ -23,7 +33,7 @@ jobs:
   
   verify:
     needs: try
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: report
         run: echo verified

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
   base:
     description: "store which base will be used in airtable"
 runs:
-  using: "node16"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Summary
- move the action runtime to Node 24
- point release/bump workflows at kungfu-systems/workflows dev/v2/v2.0
- pin release flows to action-bump-version dev/v4/v4.0 with Docker/container setup disabled for this lightweight action
- update verify runner to ubuntu-24.04 and add explicit workflow permissions

## Validation
- actionlint
- yarn build
- git diff --check
- scanned workflow/action files for legacy kungfu-trader/workflows, old Node runtimes, ubuntu-20.04, and ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION

## Notes
- Docker-based build paths are intentionally deferred until the modernized workflows/actions baseline is stable.